### PR TITLE
Remove optional full path to mocha

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "license": "BSD-3-Clause",
   "main": "index.js",
   "scripts": {
-    "test": "node node_modules/mocha/bin/mocha --recursive"
+    "test": "mocha --recursive"
   },
   "engines": {
     "node": "6.10.3",


### PR DESCRIPTION
We can reference the `mocha` binary directly since `npm` will resolve the full path it for us.