### PR TITLE
Fix outputFields comment in recipe.js

### DIFF
--- a/triggers/recipe.js
+++ b/triggers/recipe.js
@@ -60,6 +60,8 @@ module.exports = {
     //   outputFields: [
     //    () => { return []; }
     //   ]
+    // For a more complete example of using dynamic fields see
+    // https://github.com/zapier/zapier-platform-cli#customdynamic-fields.
     // Alternatively, a static field definition should be provided, to specify labels for the fields
     outputFields: [
       {key: 'id', label: 'ID'},

--- a/triggers/recipe.js
+++ b/triggers/recipe.js
@@ -57,7 +57,9 @@ module.exports = {
 
     // If the resource can have fields that are custom on a per-user basis, define a function to fetch the custom
     // field definitions. The result will be used to augment the sample.
-    // outputFields: () => { return []; }
+    //   outputFields: [
+    //    () => { return []; }
+    //   ]
     // Alternatively, a static field definition should be provided, to specify labels for the fields
     outputFields: [
       {key: 'id', label: 'ID'},


### PR DESCRIPTION
Fixes #3.

We may want expand on the comment a bit, to show how you can mix in
dynamic fields with statically defined fields.